### PR TITLE
Fix for body cells appearing as heading cells

### DIFF
--- a/src/confluenceRender.ts
+++ b/src/confluenceRender.ts
@@ -247,8 +247,8 @@ export class AtlassianWikiMarkupRenderer extends Renderer {
 		rows.forEach(row => {
 			let rowBody = row
 				.map(cell => this.tablecell(cell))
-				.join('|');
-			out += `\n|${rowBody}|`
+				.join('');
+			out += `\n${rowBody}|`
 		})
 
 		return `${out}\n`;


### PR DESCRIPTION
Fix for: https://github.com/addozhang/obsidian-confluence-converter/issues/1

This PR removes additional pipe characters that made table body cells to appear as heading cells. Let me know if you need anything adjusted.

Cheers,
Christoffer